### PR TITLE
0.8.0: Text-based object file format, (partial) object file refactoring, linker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,21 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,9 +39,8 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lc3-ensemble"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
- "crossbeam-channel",
  "logos",
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lc3-ensemble"
 rust-version="1.70"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 description = "LC-3 parser, assembler, and simulator intended for Georgia Tech's CS 2110 course"
@@ -12,6 +12,5 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossbeam-channel = "0.5.12"
 logos = "0.14.0"
 rand = "0.8.5"

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,22 @@
+# 0.8.0 (October 15, 2024)
+
+- Removed `Parse` for `u16` and `i16` (introduced in `0.7.2` to fix `.fill -32` bug) in favor for `parse::simple::IntLiteral`
+- Added support for a text-based encoding format (`TextFormat::serialize`, `TextFormat::deserialize`)
+  - Due to this change, `ObjectFile::read_bytes` and `ObjectFile::write_bytes` have been removed in favor for `BinaryFormat::serialize`/`BinaryFormat::deserialize`.
+- Linking
+  - Adds support for `.external` in the assembler
+  - Adds `ObjectFile::link` (for linking two object files)
+- Internal refactor resulting in a change in `AsmErr`:
+  - `AsmErr::ExcessiveBlock` is removed
+  - `AsmErr::BlockInIO` and `AsmErr::WrappingBlock` for object files that write to IO and those that wrap memory
+
 # 0.7.2 (October 2, 2024)
 
 - Fixed bug where `.fill -32` (or any negative number) would error.
 
 # 0.7.1 (September 20, 2024)
 
-- Added new SourceInfo APIs that allow constructing SourceInfo structs from source strings 
+- Added new SourceInfo APIs that allow constructing SourceInfo structs from source strings.
   - `SourceInfo::new`, `SourceInfo::from(String)`
 
 # 0.7.0 (September 19, 2024)

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -1546,4 +1546,43 @@ mod tests {
         let mut de = TextFormat::deserialize(&ser).expect("text encoding should've been parseable");
         assert_obj_equal(&mut de, &obj, "text encoding could not be roundtripped");
     }
+
+    #[test]
+    fn test_basic_link() {
+        let library = "
+            .orig x5000
+                ADDER ADD R2, R0, R1
+                RET
+            .end
+        ";
+
+        let program = "
+            .external ADDER
+
+            .orig x4000
+                LD R0, A
+                LD R1, B
+
+                LD R3, ADDER_ADDR
+                JSRR R3
+
+                HALT
+
+                A .fill 10
+                B .fill 20
+                ADDER_ADDR .fill ADDER
+            .end
+        ";
+
+        let lib_obj = assemble_src(library).unwrap();
+        let prog_obj = assemble_src(program).unwrap();
+        ObjectFile::link(lib_obj, prog_obj).unwrap();
+
+        // TODO: Check... 
+        // - overlapping labels
+        // - overlapping blocks
+        // - linking two files with the same external
+        // - object file encoding w/ linkage
+        // - using external label in offset operand
+    }
 }

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -327,6 +327,7 @@ impl SourceInfo {
         let nl_indices: Vec<_> = src
             .match_indices('\n')
             .map(|(i, _)| i)
+            .chain([src.len()])
             .collect();
 
         Self { src, nl_indices }
@@ -340,7 +341,7 @@ impl SourceInfo {
     /// Counts the number of lines in the source string.
     pub fn count_lines(&self) -> usize {
         // The first line, plus every line after (delimited by a new line)
-        self.nl_indices.len() + 1
+        self.nl_indices.len()
     }
 
     /// Gets the character range for the provided line, including any whitespace.
@@ -349,14 +350,12 @@ impl SourceInfo {
     fn raw_line_span(&self, line: usize) -> Option<Range<usize>> {
         // Implementation detail:
         // number of lines = self.nl_indices.len() + 1
-        if !(0..=self.nl_indices.len()).contains(&line) {
+        if !(0..self.count_lines()).contains(&line) {
             return None;
         };
 
-        let end = match self.nl_indices.get(line) {
-            Some(&n) => n,
-            None     => self.src.len(),
-        };
+        let &end = self.nl_indices.get(line)
+            .unwrap_or_else(|| self.nl_indices.last().unwrap());
         
         let start = match line == 0 {
             false => self.nl_indices[line - 1] + 1,

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -10,7 +10,7 @@
 //! 
 //! [`Stmt`]: crate::ast::asm::Stmt
 
-mod encoding;
+pub mod encoding;
 
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
@@ -22,7 +22,6 @@ use crate::ast::asm::{AsmInstr, Directive, Stmt, StmtKind};
 use crate::ast::sim::SimInstr;
 use crate::ast::{IOffset, ImmOrReg, Offset, OffsetNewErr, PCOffset, Reg};
 use crate::err::ErrSpan;
-
 
 /// Assembles a assembly source code AST into an object file.
 /// 

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -199,6 +199,7 @@ const IO_START: u16 = 0xFE00;
 /// 9 | .end
 /// ```
 /// maps to `LineSymbolMap({1: [0x3000, 0x3001, 0x3002], 7: [0x4000, 0x4005]})`.
+#[derive(PartialEq, Eq)]
 struct LineSymbolMap(BTreeMap<usize, Vec<u16>>);
 
 impl LineSymbolMap {
@@ -271,6 +272,7 @@ impl std::fmt::Debug for LineSymbolMap {
 }
 /// Struct holding the source string and contains helpers 
 /// to index lines and to query position information from a source string.
+#[derive(PartialEq, Eq)]
 pub struct SourceInfo {
     /// The source code.
     src: String,
@@ -418,6 +420,7 @@ impl From<String> for SourceInfo {
 /// text is available during simulation time:
 /// - Mappings from source code line numbers to memory addresses
 /// - Source code text (which grants access to line contents from a given line number; see [`SourceInfo`] for more details)
+#[derive(PartialEq, Eq)]
 pub struct SymbolTable {
     /// A mapping from label to address and span of the label.
     label_map: HashMap<String, (u16, usize)>,
@@ -880,7 +883,7 @@ impl Directive {
 /// 
 /// This is the final product after assembly source code is fully assembled.
 /// This can be loaded in the simulator to run the assembled code.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ObjectFile {
     /// A mapping of each block's address to its corresponding data.
     /// 

--- a/src/asm/encoding.rs
+++ b/src/asm/encoding.rs
@@ -43,7 +43,7 @@ impl ObjectFile {
         // the source code (n bytes)
         
         let mut bytes = vec![];
-        for (&addr, data) in self.block_map.iter() {
+        for (addr, data) in self.block_iter() {
             bytes.push(0x00);
             bytes.extend(u16::to_le_bytes(addr));
             bytes.extend(u16::to_le_bytes(data.len() as u16));

--- a/src/asm/encoding.rs
+++ b/src/asm/encoding.rs
@@ -3,8 +3,10 @@
 //! The [`ObjFileFormat`] trait describes an implementation of reading/writing object files into disk.
 //! This module provides an implementation of the trait:
 //! - [`BinaryFormat`]: A binary representation of object file data
+//! - [`TextFormat`]: A text representation of object file data
 
 use std::collections::{BTreeMap, HashMap};
+use std::fmt::Write;
 
 use super::{ObjectFile, SymbolTable};
 
@@ -240,4 +242,325 @@ fn assert_sorted_no_dup<T: Ord>(data: &[T]) -> Option<()> {
         .map(|w| <&[_; 2]>::try_from(w).unwrap())
         .all(|[l, r]| l < r)
         .then_some(())
+}
+
+// TEXT!
+/// A text-based format of object file data.
+pub struct TextFormat;
+
+const TFMT_MAGIC: &str = "LC-3 OBJ FILE";
+const TFMT_UNINIT: &str = "????";
+const TABLE_DIV: &str = " | ";
+
+impl ObjFileFormat for TextFormat {
+    type Stream = str;
+
+    fn serialize(o: &ObjectFile) -> <Self::Stream as ToOwned>::Owned {
+        // Text format specification.
+        //
+        // ```text
+        // LC-3 OBJ FILE
+        // 
+        // .TEXT
+        // <start address in hex>
+        // <length of segment in dec>
+        // <instruction in hex>
+        // <...>
+        //
+        // .SYMBOL
+        // ADDR | EXTERNAL | LABEL
+        // 0000 | 0        | FOO  
+        // 0001 | 0        | BAR  
+        // ...
+        //
+        // .DEBUG
+        // LABEL | INDEX
+        // FOO   | 35
+        // BAR   | 94
+        // ====================
+        // LINE | ADDR | SOURCE
+        // 0    | 9090 | ......
+        // 1    | 9091 | ......
+        // ====================
+        // ...
+        // // Support for comments, as well.
+        // ```
+        //
+        // For a given `instruction in hex`, it prints the ASCII-hex encoding, returning ???? if uninitialized.
+        fn _ser(o: &ObjectFile) -> Result<String, std::fmt::Error> {
+            use std::fmt::Write;
+            let mut buf = String::new();
+
+            writeln!(buf, "{TFMT_MAGIC}")?;
+            writeln!(buf)?;
+            
+            writeln!(buf, ".TEXT")?;
+            for (addr, block) in o.block_iter() {
+                writeln!(buf, "{addr:04X}")?;
+                writeln!(buf, "{}", block.len())?;
+                for &m_instr in block {
+                    match m_instr {
+                        Some(instr) => writeln!(buf, "{instr:04X}")?,
+                        None => writeln!(buf, "{TFMT_UNINIT}")?,
+                    }
+                }
+            }
+            writeln!(buf)?;
+
+            if let Some(sym) = &o.sym {
+                writeln!(buf, ".SYMBOL")?;
+                if !sym.label_map.is_empty() {
+                    writeln!(buf, "ADDR{0}LABEL", TABLE_DIV)?;
+                    for (label, addr) in sym.label_iter() {
+                        writeln!(buf, "{addr:04X}{0}{label}", TABLE_DIV)?;
+                    }
+                }
+                writeln!(buf)?;
+                
+                writeln!(buf, ".DEBUG")?;
+                writeln!(buf, "// DEBUG SYMBOLS FOR LC3TOOLS")?;
+                writeln!(buf)?;
+
+                // Display label to index mapping
+                const LABEL: &str = "LABEL";
+                const INDEX: &str = "INDEX";
+                
+                if !sym.label_map.is_empty() {
+                    // Calculate label & index column lengths
+                    let (label_col, index_col) = sym.label_map.iter()
+                        .map(|(s, &(_, span_start))| (s.len(), count_digits(span_start)))
+                        .fold(
+                            (LABEL.len(), INDEX.len()), 
+                            |(lc, ic), (lx, ix)| (lc.max(lx), ic.max(ix))
+                        );
+
+                    // Display!
+                    writeln!(buf, "{LABEL:1$}{0}{INDEX:2$}", TABLE_DIV, label_col, index_col)?;
+                    for (label, &(_, span_start)) in sym.label_map.iter() {
+                        writeln!(buf, "{label:1$}{0}{span_start:2$}", TABLE_DIV, label_col, index_col)?;
+                    }
+                }
+                writeln!(buf, "====================")?;
+
+                // Create line table
+                let mut line_table: BTreeMap<usize, (Option<usize>, Option<u16>)> = BTreeMap::new();
+                if let Some(src) = &sym.src_info {
+                    line_table.extend({
+                        src.nl_indices.iter().enumerate()
+                            .map(|(lno, &idx)| (lno, (Some(idx), None)))
+                    });
+                }
+                for (&start_line, block) in sym.line_map.0.iter() {
+                    for (i, &addr) in block.iter().enumerate() {
+                        let (_, entry_addr) = line_table.entry(start_line.wrapping_add(i)).or_default();
+                        entry_addr.replace(addr);
+                    }
+                }
+
+                // Display line table
+                const LINE: &str = "LINE";
+                if !line_table.is_empty() {
+                    // Compute line & index column length
+                    let (mut last_line, mut last_index) = (None, None);
+                    for (&line, &(index, _)) in line_table.iter().rev() {
+                        if last_line.is_none() { last_line.replace(line); }
+                        if last_index.is_none() { last_index = index; }
+
+                        if last_line.is_some() && last_index.is_some() {
+                            break;
+                        }
+                    }
+                    let line_col = LINE.len().max(count_digits(last_line.unwrap_or(0)));
+
+                    // Display!
+                    writeln!(buf, "{LINE:1$}{0}ADDR{0}SOURCE", TABLE_DIV, line_col)?;
+                    for (line, (_, m_addr)) in line_table {
+                        write!(buf, "{line:0$}", line_col)?;
+                        write!(buf, "{TABLE_DIV}")?;
+                        match m_addr {
+                            Some(addr) => write!(buf, "{addr:04X}"),
+                            None => write!(buf, "{TFMT_UNINIT}")
+                        }?;
+                        write!(buf, "{TABLE_DIV}")?;
+
+                        // Line:
+                        let src_line = sym.src_info.as_ref()
+                            .and_then(|s| Some(&s.source()[s.raw_line_span(line)?]))
+                            .unwrap_or("");
+                        write!(buf, "{src_line}")?;
+
+                        writeln!(buf)?;
+                    }
+                }
+
+                writeln!(buf, "====================")?;
+            }
+
+
+            Ok(buf)
+        }
+
+        _ser(o).unwrap()
+    }
+
+    fn deserialize(string: &Self::Stream) -> Option<ObjectFile> {
+        // Warning: spaghetti.
+
+        let mut block_map  = BTreeMap::new();
+        let mut label_map  = HashMap::<_, (_, _)>::new();
+        let mut line_map   = vec![];
+        let mut src        = None;
+
+        // Read all of the non-empty lines:
+        let mut lines = string.trim().lines()
+            .map(|l| {
+                l.split_once("//").map_or(l, |(left, _)| left) // remove comments
+            })
+            .filter(|&l| !l.trim().is_empty());
+        if lines.next() != Some(TFMT_MAGIC) { return None };
+
+        let mut line_groups = vec![];
+        for line in lines {
+            if line.starts_with('.') {
+                line_groups.push(vec![line]);
+            } else {
+                line_groups.last_mut()?.push(line);
+            }
+        }
+        for group in line_groups {
+            let [header, rest @ ..] = &*group else { return None };
+            match *header {
+                ".TEXT" => {
+                    let mut it = rest.iter();
+                    while let Some(orig_hex) = it.next() {
+                        let orig = hex2u16(orig_hex)?;
+                        let block_len = it.next()?.parse::<u16>().ok()?;
+
+                        // Get and parse block of hex:
+                        let block: Vec<_> = it.by_ref().take(usize::from(block_len))
+                            .copied()
+                            .map(maybe_hex2u16)
+                            .collect::<Option<_>>()?;
+
+                        if block.len() != usize::from(block_len) { return None; }
+                        match block_map.entry(orig) {
+                            std::collections::btree_map::Entry::Vacant(e) => e.insert(block),
+                            std::collections::btree_map::Entry::Occupied(_) => return None,
+                        };
+                    }
+                },
+                ".SYMBOL" => {
+                    let table = parse_table(rest, ["ADDR", "LABEL"], |[addr_hex, label], _| {
+                        let addr = hex2u16(addr_hex)?;
+                        Some((addr, label))
+                    }, true)?;
+
+                    for (addr, label) in table {
+                        // TODO: what happens if .SYMBOL label + .DEBUG label mismatch
+                        label_map.entry(label.to_string()).or_default().0 = addr;
+                    }
+                },
+                ".DEBUG" => if !rest.is_empty() {
+                    let split_pos = rest.iter().position(|l| l.starts_with('='))?;
+                    if !rest.last()?.starts_with('=') { return None; }
+                    let (label_src, [_, line_src @ .., _]) = rest.split_at(split_pos) else { unreachable!("divider should be present") };
+
+                    let label_table = parse_table(label_src, ["LABEL", "INDEX"], |[label, index_str], _| {
+                        let index = index_str.parse().ok()?;
+                        Some((label, index))
+                    }, true)?;
+                    for (label, index) in label_table {
+                        label_map.entry(label.to_string()).or_default().1 = index;
+                    }
+
+                    let mut line_table = parse_table(line_src, ["LINE", "ADDR", "SOURCE"], |cols, i| {
+                        let [rest @ .., source_str] = cols;
+                        let [line_str, addr_str] = rest.map(str::trim);
+                        
+                        if line_str.parse::<usize>().ok()? != i { return None; }
+                        let m_addr = maybe_hex2u16(addr_str)?;
+                        Some((m_addr, source_str))
+                    }, false)?;
+
+                    if let Some((last_m_addr, last_line)) = line_table.pop() {
+                        let s = src.get_or_insert_with(String::new);
+
+                        for (m_addr, line) in line_table {
+                            line_map.push(m_addr);
+                            writeln!(s, "{line}").unwrap();
+                        }
+                        
+                        line_map.push(last_m_addr);
+                        write!(s, "{last_line}").unwrap();
+                    }
+                },
+                _ => return None
+            }
+        }
+
+        let sym = match !label_map.is_empty() || !line_map.is_empty() || src.is_some() {
+            true => Some(SymbolTable {
+                label_map,
+                src_info: src.map(super::SourceInfo::from_string),
+                line_map: super::LineSymbolMap::new(line_map)
+            }),
+            false => None,
+        };
+        Some(ObjectFile {
+            block_map,
+            sym,
+        })
+    }
+}
+
+fn count_digits(n: usize) -> usize {
+    (n.checked_ilog10().unwrap_or(0) + 1) as usize
+}
+fn hex2u16(s: &str) -> Option<u16> {
+    match s.len() == 4 {
+        true => u16::from_str_radix(s, 16).ok(),
+        false => None
+    }
+}
+fn maybe_hex2u16(s: &str) -> Option<Option<u16>> {
+    match s {
+        TFMT_UNINIT => Some(None),
+        s => hex2u16(s).map(Some)
+    }
+}
+
+fn parse_header(line: &str, columns: &[&str]) -> Option<()> {
+    line.splitn(columns.len(), TABLE_DIV)
+        .map(str::trim)
+        .eq(columns.iter().copied())
+        .then_some(())
+}
+fn parse_row<'a, T, const N: usize>(line: &'a str, f: impl FnOnce([&'a str; N]) -> Option<T>) -> Option<T> {
+    let mut segments: Vec<_> = line
+        .splitn(N, TABLE_DIV)
+        .collect();
+    segments.resize(N, "");
+    let segments = *<Box<[_; N]>>::try_from(segments).ok()?;
+    f(segments)
+}
+fn parse_table<'a, T, const N: usize>(
+    contents: &[&'a str],
+    columns: [&str; N], 
+    mut row_parser: impl FnMut([&'a str; N], usize) -> Option<T>,
+    trim: bool
+) -> Option<Vec<T>> {
+    // Accept empty tables:
+    let Some((header, body)) = contents.split_first() else {
+        return Some(vec![])
+    };
+
+    let trimfn = |s| match trim {
+        true  => str::trim(s),
+        false => s,
+    };
+    parse_header(header, &columns)?;
+    body.iter()
+        .enumerate()
+        .map(|(i, l)| parse_row(l, |r| row_parser(r.map(trimfn), i)))
+        .collect()
 }

--- a/src/asm/encoding.rs
+++ b/src/asm/encoding.rs
@@ -205,7 +205,7 @@ impl ObjFileFormat for BinaryFormat {
                     }),
                     false => None,
                 },
-                line_map: super::LineSymbolMap(line_map)
+                line_map: super::LineSymbolMap::from_blocks(line_map)?
             }),
             false => None,
         };
@@ -502,7 +502,7 @@ impl ObjFileFormat for TextFormat {
             true => Some(SymbolTable {
                 label_map,
                 src_info: src.map(super::SourceInfo::from_string),
-                line_map: super::LineSymbolMap::new(line_map)
+                line_map: super::LineSymbolMap::new(line_map)?
             }),
             false => None,
         };

--- a/src/ast/asm.rs
+++ b/src/ast/asm.rs
@@ -416,7 +416,18 @@ pub enum Directive {
     /// 
     /// `.end`
     End,
-    // External
+
+    /// A `.external` directive.
+    /// 
+    /// # Operation
+    /// 
+    /// Designates that a label is external, 
+    /// meaning it is not defined within the file and must be linked in.
+    /// 
+    /// # Syntax
+    /// 
+    /// `.external LABEL`
+    External(Label),
 }
 impl std::fmt::Display for Directive {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -426,6 +437,7 @@ impl std::fmt::Display for Directive {
             Self::Blkw(n)      => write!(f, ".blkw {n}"),
             Self::Stringz(val) => write!(f, ".stringz {val:?}"),
             Self::End          => write!(f, ".end"),
+            Self::External(lb) => write!(f, ".external {lb}"),
         }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -658,9 +658,10 @@ impl Parse for Directive {
                 Ok(Self::Stringz(s))
             }
             "END" => Ok(Self::End),
+            "EXTERNAL" => Ok(Self::External(parser.parse()?)),
             _ => Err({
                 ParseErr::new("invalid directive", cursor)
-                    .with_help("the valid directives are .orig, .fill, .blkw, .stringz, .end")
+                    .with_help("the valid directives are .orig, .fill, .blkw, .stringz, .end, .external")
             })
         }
     }

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -809,7 +809,7 @@ impl Simulator {
 
         let mut alloca = vec![];
 
-        for (start, words) in obj.iter() {
+        for (start, words) in obj.block_iter() {
             self.mem.copy_obj_block(start, words);
 
             // add this block to alloca

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -829,6 +829,8 @@ impl Simulator {
 
         alloca.sort_by_key(|&(start, _)| start);
         self.alloca = alloca.into_boxed_slice();
+
+        // TODO: Fail on external label present.
     }
 
     /// Sets the condition codes using the provided result.


### PR DESCRIPTION
Introduces:
- Text-based object file format
- A partial refactoring of the object file format code
- Spaghettification of the object file format code to support linking
- Linking

Resolves #2.

A secondary refactoring *should* occur in the future in order to clean up the rough edges around this linker implementation, namely:
- errors are not handled particularly well for the linking process
- test cases need to be checked
- debug symbols need to be handled more sufficiently (removal of ASM in object files, allowing object files to reference more than one ASM file)
- object files with unresolved external symbols should probably not be loadable in the simulator
- improve safeguarding around enc/decode
- removing redundant code