### PR TITLE
Add unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,6 @@
 /target
 
-
-# Added by cargo
-#
-# already existing elements were commented out
-
-#/target
-
 .vscode
 **/venv
+
+mutants.*/

--- a/src/err.rs
+++ b/src/err.rs
@@ -103,20 +103,26 @@ impl From<Span> for ErrSpan {
         ErrSpan::One(value)
     }
 }
-impl From<[Span; 2]> for ErrSpan {
-    fn from(value: [Span; 2]) -> Self {
-        ErrSpan::Two(value)
+impl From<&[Span]> for ErrSpan {
+    fn from(value: &[Span]) -> Self {
+        match value {
+            [r0] => ErrSpan::One(r0.clone()),
+            [r0, r1] => ErrSpan::Two([r0.clone(), r1.clone()]),
+            rr => ErrSpan::Many(rr.to_vec())
+        }
+    }
+}
+impl<const N: usize> From<[Span; N]> for ErrSpan {
+    fn from(value: [Span; N]) -> Self {
+        Self::from(value.as_slice())
     }
 }
 impl From<Vec<Span>> for ErrSpan {
     fn from(value: Vec<Span>) -> Self {
-        match Box::<[_; 1]>::try_from(value) {
-            Ok(rbox) => {
-                let [r] = *rbox;
-                ErrSpan::One(r)
-            },
-            Err(value) => match Box::try_from(value) {
-                Ok(rbox) => ErrSpan::Two(*rbox),
+        match <[_; 1]>::try_from(value) {
+            Ok([r]) => ErrSpan::One(r),
+            Err(value) => match <[_; 2]>::try_from(value) {
+                Ok(r2) => ErrSpan::Two(r2),
                 Err(value) => ErrSpan::Many(value)
             }
         }

--- a/src/parse/lex.rs
+++ b/src/parse/lex.rs
@@ -298,3 +298,310 @@ fn lex_str_literal(lx: &mut Lexer<'_, Token>) -> Result<String, LexErr> {
         false => Err(LexErr::StrLitTooBig),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use logos::Logos;
+
+    use crate::err::LexErr;
+    use crate::parse::lex::{Ident, Token};
+
+    fn label(s: &str) -> Token {
+        Token::Ident(Ident::Label(s.to_string()))
+    }
+    fn directive(s: &str) -> Token {
+        Token::Directive(s.to_string())
+    }
+    fn str_literal(s: &str) -> Token {
+        Token::String(s.to_string())
+    }
+
+    #[test]
+    fn test_numeric_dec_success() {
+        // Basic
+        let mut tokens = Token::lexer("0 123 456 789");
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(123))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(456))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(789))));
+        assert_eq!(tokens.next(), None);
+
+        // Negative
+        let mut tokens = Token::lexer("-123 -456 -789");
+        assert_eq!(tokens.next(), Some(Ok(Token::Signed(-123))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Signed(-456))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Signed(-789))));
+        assert_eq!(tokens.next(), None);
+        
+        // Alternate syntax
+        let mut tokens = Token::lexer("#100 #200 #-300");
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(100))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(200))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Signed(-300))));
+        assert_eq!(tokens.next(), None);
+    }
+    #[test]
+    fn test_numeric_hex_success() {
+        // Basic
+        let mut tokens = Token::lexer("x2110 xABCD X2110 XABCD Xabcd XaBcD xA xAA xAAA xAAAA");
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0x2110))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0xABCD))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0x2110))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0xABCD))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0xABCD))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0xABCD))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0x000A))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0x00AA))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0x0AAA))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0xAAAA))));
+        assert_eq!(tokens.next(), None);
+
+        // Negative
+        let mut tokens = Token::lexer("x-9 x-1234 X-1234");
+        assert_eq!(tokens.next(), Some(Ok(Token::Signed(-0x9))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Signed(-0x1234))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Signed(-0x1234))));
+        assert_eq!(tokens.next(), None);
+    }
+    
+    #[test]
+    fn test_numeric_dec_overflow() {
+        // Overflow success tests
+        let mut tokens = Token::lexer("32767 32768 -1 -32767 -32768 65535");
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(32767))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(32768))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Signed(-1))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Signed(-32767))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Signed(-32768))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(65535))));
+        assert_eq!(tokens.next(), None);
+
+        // Overflow failure tests
+        assert_eq!(Token::lexer("65536").next(), Some(Err(LexErr::DoesNotFitU16)));
+        assert_eq!(Token::lexer("999999999999999999999999999999").next(), Some(Err(LexErr::DoesNotFitU16)));
+        assert_eq!(Token::lexer("-32769").next(), Some(Err(LexErr::DoesNotFitI16)));
+        assert_eq!(Token::lexer("-65536").next(), Some(Err(LexErr::DoesNotFitI16)));
+    }
+    
+    #[test]
+    fn test_numeric_hex_overflow() {
+        // Overflow success tests
+        let mut tokens = Token::lexer("x0000 x7FFF x8000 xFFFF x-7FFF x-8000");
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0x0000))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0x7FFF))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0x8000))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0xFFFF))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Signed(-0x7FFF))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Signed(-0x8000))));
+        assert_eq!(tokens.next(), None);
+
+        // Overflow failure tests
+        assert_eq!(Token::lexer("xABCDEF").next(), Some(Err(LexErr::DoesNotFitU16)));
+        assert_eq!(Token::lexer("x0123456789ABCDEF0123456789ABCDEF").next(), Some(Err(LexErr::DoesNotFitU16)));
+        assert_eq!(Token::lexer("x-8001").next(), Some(Err(LexErr::DoesNotFitI16)));
+        assert_eq!(Token::lexer("x-FFFF").next(), Some(Err(LexErr::DoesNotFitI16)));
+    }
+
+    #[test]
+    fn test_numeric_dec_invalid() {
+        assert_eq!(Token::lexer("#Q").next(), Some(Err(LexErr::InvalidNumeric)));
+        assert_eq!(Token::lexer("3Q").next(), Some(Err(LexErr::InvalidNumeric)));
+        assert_eq!(Token::lexer("##").next(), Some(Err(LexErr::InvalidNumeric)));
+        assert_eq!(Token::lexer("#").next(), Some(Err(LexErr::InvalidDecEmpty)));
+        assert_eq!(Token::lexer("#-").next(), Some(Err(LexErr::InvalidDecEmpty)));
+        assert_eq!(Token::lexer("-#1").next(), Some(Err(LexErr::InvalidNumeric)));
+    }
+    
+    #[test]
+    fn test_numeric_hex_invalid() {
+        assert_eq!(Token::lexer("x0Q").next(), Some(Err(LexErr::InvalidHex)));
+        assert_eq!(Token::lexer("x-").next(), Some(Err(LexErr::InvalidHexEmpty)));
+        assert_eq!(Token::lexer("-x7FFF").next(), Some(Err(LexErr::InvalidNumeric)));
+    }
+
+    #[test]
+    fn test_regs() {
+        // Successes:
+        let mut tokens = Token::lexer("R0 R1 R2 R3 R4 R5 R6 R7");
+        assert_eq!(tokens.next(), Some(Ok(Token::Reg(0))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Reg(1))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Reg(2))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Reg(3))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Reg(4))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Reg(5))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Reg(6))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Reg(7))));
+        assert_eq!(tokens.next(), None);
+
+        // Failures:
+        assert_eq!(Token::lexer("R8").next(), Some(Err(LexErr::InvalidReg)));
+        assert_eq!(Token::lexer("R9").next(), Some(Err(LexErr::InvalidReg)));
+        assert_eq!(Token::lexer("R10").next(), Some(Err(LexErr::InvalidReg)));
+        assert_eq!(Token::lexer("R99999999").next(), Some(Err(LexErr::InvalidReg)));
+        
+        assert_eq!(Token::lexer("R-1").collect::<Result<Vec<_>, _>>(), Ok(vec![
+            label("R"),
+            Token::Signed(-1)
+        ]));
+    }
+
+    #[test]
+    fn test_str() {
+        // Basic
+        let mut tokens = Token::lexer(r#" " " "abc" "def" "!@#$%^&*()" "#);
+        assert_eq!(tokens.next(), Some(Ok(str_literal(" "))));
+        assert_eq!(tokens.next(), Some(Ok(str_literal("abc"))));
+        assert_eq!(tokens.next(), Some(Ok(str_literal("def"))));
+        assert_eq!(tokens.next(), Some(Ok(str_literal("!@#$%^&*()"))));
+        assert_eq!(tokens.next(), None);
+    }
+
+    #[test]
+    fn test_str_empty() {
+        // Empty
+        let mut tokens = Token::lexer(r#" "" "#);
+        assert_eq!(tokens.next(), Some(Ok(str_literal(""))));
+        assert_eq!(tokens.next(), None);
+    }
+
+    #[test]
+    fn test_str_escape() {
+        // Escapes
+        let mut tokens = Token::lexer(r#" "\n" "\r" "\t" "\\" "\"" "\0" "\e" "#);
+        assert_eq!(tokens.next(), Some(Ok(str_literal("\n"))));
+        assert_eq!(tokens.next(), Some(Ok(str_literal("\r"))));
+        assert_eq!(tokens.next(), Some(Ok(str_literal("\t"))));
+        assert_eq!(tokens.next(), Some(Ok(str_literal("\\"))));
+        assert_eq!(tokens.next(), Some(Ok(str_literal("\""))));
+        assert_eq!(tokens.next(), Some(Ok(str_literal("\0"))));
+        assert_eq!(tokens.next(), Some(Ok(str_literal("\\e"))));
+        assert_eq!(tokens.next(), None);
+
+        let mut tokens = Token::lexer(r#" "wqftnzsegpfykvzekyvketskestve\nsreatkrsetkrsetksretnrsk" "#);
+        assert_eq!(tokens.next(), Some(Ok(str_literal("wqftnzsegpfykvzekyvketskestve\nsreatkrsetkrsetksretnrsk"))));
+        assert_eq!(tokens.next(), None);
+
+    }
+
+    #[test]
+    fn test_str_big() {
+        let mut large;
+        // .len() == 32767
+        large = "0".repeat(32767);
+        assert_eq!(Token::lexer(&format!(r#""{large}""#)).next(), Some(Ok(str_literal(&large))));
+        // .len() == 32768
+        large.push('0');
+        assert_eq!(Token::lexer(&format!(r#""{large}""#)).next(), Some(Ok(str_literal(&large))));
+        // .len() == 32769
+        large.push('0');
+        assert_eq!(Token::lexer(&format!(r#""{large}""#)).next(), Some(Ok(str_literal(&large))));
+        
+        // .len() == .65533
+        large = "0".repeat(65533);
+        assert_eq!(Token::lexer(&format!(r#""{large}""#)).next(), Some(Ok(str_literal(&large))));
+        // .len() == .65534
+        large.push('0');
+        assert_eq!(Token::lexer(&format!(r#""{large}""#)).next(), Some(Ok(str_literal(&large))));
+        // .len() == .65535
+        large.push('0');
+        assert_eq!(Token::lexer(&format!(r#""{large}""#)).next(), Some(Err(LexErr::StrLitTooBig)));
+        // .len() == .65536
+        large.push('0');
+        assert_eq!(Token::lexer(&format!(r#""{large}""#)).next(), Some(Err(LexErr::StrLitTooBig)));
+
+        // With escape:
+        let input = format!(r#""{:065533}\n""#, 0);
+        let parsed = format!("{:065533}\n", 0);
+        assert_eq!(Token::lexer(&input).next(), Some(Ok(str_literal(&parsed))));
+    }
+
+    #[test]
+    fn test_str_unclosed() {
+        assert_eq!(Token::lexer(r#"""#).next(), Some(Err(LexErr::UnclosedStrLit)));
+        assert_eq!(Token::lexer(r#""
+        ""#).next(), Some(Err(LexErr::UnclosedStrLit)));
+    }
+
+    #[test]
+    fn test_keywords_labels() {
+        let kws = stringify!(
+            ADD AND NOT BR BRP BRZ BRZP BRN BRNP BRNZ BRNZP 
+            JMP JSR JSRR LD LDI LDR LEA ST STI STR TRAP NOP 
+            RET RTI GETC OUT PUTC PUTS IN PUTSP HALT
+        );
+        for m_token in Token::lexer(kws) {
+            let token = m_token.unwrap();
+            if let Token::NewLine = token { continue; }
+            assert!(
+                matches!(token, Token::Ident(_)) & !matches!(token, Token::Ident(Ident::Label(_))), 
+                "Expected {token:?} to be keyword"
+            );
+        }
+
+        // Case insensitivity
+        let mut tokens = Token::lexer("ADD ADd AdD Add aDD aDd adD add");
+        assert_eq!(tokens.next(), Some(Ok(Token::Ident(Ident::ADD))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Ident(Ident::ADD))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Ident(Ident::ADD))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Ident(Ident::ADD))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Ident(Ident::ADD))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Ident(Ident::ADD))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Ident(Ident::ADD))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Ident(Ident::ADD))));
+        assert_eq!(tokens.next(), None);
+
+        // Labels
+        let mut tokens = Token::lexer("ARST gmneio _");
+        assert_eq!(tokens.next(), Some(Ok(label("ARST"))));
+        assert_eq!(tokens.next(), Some(Ok(label("gmneio"))));
+        assert_eq!(tokens.next(), Some(Ok(label("_"))));
+        assert_eq!(tokens.next(), None);
+    }
+
+    #[test]
+    fn test_directive() {
+        let mut tokens = Token::lexer(".fill .abc .2a ._");
+        assert_eq!(tokens.next(), Some(Ok(directive("fill"))));
+        assert_eq!(tokens.next(), Some(Ok(directive("abc"))));
+        assert_eq!(tokens.next(), Some(Ok(directive("2a"))));
+        assert_eq!(tokens.next(), Some(Ok(directive("_"))));
+        assert_eq!(tokens.next(), None);
+    }
+
+    #[test]
+    fn test_punct() {
+        let mut tokens = Token::lexer("0\n1,2:3 ;; abcdef");
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(0))));
+        assert_eq!(tokens.next(), Some(Ok(Token::NewLine)));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(1))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Comma)));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(2))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Colon)));
+        assert_eq!(tokens.next(), Some(Ok(Token::Unsigned(3))));
+        assert_eq!(tokens.next(), Some(Ok(Token::Comment)));
+    }
+
+    #[test]
+    fn test_invalid_symbol() {
+        let invalid = b"\
+        \x00\x01\x02\x03\x04\x05\x06\x07\x08        \x0B\x0C\x0D\x0E\x0F\
+        \x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\
+            \x21        \x24\x25\x26\x27\x28\x29\x2A\x2B            \x2F\
+                                                        \x3C\x3D\x3E\x3F\
+        \x40                                                            \
+                                                    \x5B\x5C\x5D\x5E    \
+        \x60                                                            \
+                                                    \x7B\x7C\x7D\x7E\x7F\
+        ";
+        for &c in invalid {
+            if c == b' ' { continue; }
+            let slice = &[c];
+            let string = std::str::from_utf8(slice).unwrap();
+            assert_eq!(
+                Token::lexer(string).next(),
+                Some(Err(LexErr::InvalidSymbol)),
+                "Expected {string:?} (0x{c:02X}) to be an invalid symbol"
+            );
+        }
+    }
+}

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -318,7 +318,6 @@ pub enum SimErr {
     /// (including uninitialized registers).
     /// This also ignores loads from allocated (`.blkw`) memory in case the program writer
     /// uses those as register stores.
-
     // IDEA: So currently, the way this is implemented is that LDR Rx, R6, OFF is accepted regardless of initialization.
     // We could make this stricter by keeping track of how much is allocated on the stack.
     StrictRegSetUninit,
@@ -328,7 +327,6 @@ pub enum SimErr {
     /// (including uninitialized registers).
     /// This also ignores loads from allocated (`.blkw`) memory in case the program writer
     /// uses those as register stores.
-
     // IDEA: See StrictRegSetUninit.
     StrictMemSetUninit,
     /// Data was stored into MMIO with a partially uninitialized value.


### PR DESCRIPTION
Adds unit testing for lexer, parser, and symbol table + object files. This doesn't add unit testing for the `sim` module.