### PR TITLE
0.10.0: Access observer and `mmap_internal` APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lc3-ensemble"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "logos",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lc3-ensemble"
 rust-version="1.85"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2024"
 license = "MIT"
 description = "LC-3 parser, assembler, and simulator intended for Georgia Tech's CS 2110 course"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+# 0.10.0 (May 5, 2025)
+
+- Access Observer
+  - (Breaking) Replaced the previous `ChangeObserver` API into the `AccessObserver` API. This API allows for checking whether a memory location was accessed (expanding the previous functionality of checking whether a memory location was "changed")
+  - Exposed the `observer` module (which was incorrectly hidden, oops)
+  - Added `SimFlags::track_access` to allow individual reads or writes from being tracked in `AccessObserver`.
+- Internal Register/`mmap_internal` API
+  - API to expose internal registers (PC and SavedSP) as MMIO
+  - Added `Simulator::mmap_internal` and `Simulator::munmap_internal` to facilitate this functionality
+
 # 0.9.2 (December 18, 2024)
 
 - Bug fixes

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -50,6 +50,9 @@ pub enum Reg {
     R7 = 7
 }
 impl Reg {
+    /// The number of registers defined by the LC-3 ISA.
+    pub(crate) const REG_SIZE: usize = 8;
+
     /// Gets the register number of this [`Reg`]. This is always between 0 and 7.
     pub fn reg_no(self) -> u8 {
         self as u8

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -280,7 +280,7 @@ pub mod mem;
 pub mod debug;
 pub mod frame;
 pub mod device;
-mod observer;
+pub mod observer;
 
 use std::collections::HashSet;
 use std::sync::atomic::AtomicBool;

--- a/src/sim/mem.rs
+++ b/src/sim/mem.rs
@@ -485,7 +485,7 @@ impl std::ops::IndexMut<u16> for MemArray {
 /// assert_eq!(reg[R0].get(), 11);
 /// ```
 #[derive(Debug, Clone)]
-pub struct RegFile([Word; 8]);
+pub struct RegFile([Word; Reg::REG_SIZE]);
 impl RegFile {
     /// Creates a register file with uninitialized data.
     pub fn new(filler: &mut impl WordFiller) -> Self {

--- a/src/sim/observer.rs
+++ b/src/sim/observer.rs
@@ -1,9 +1,29 @@
-//! A small module that tracks changes in memory,
-//! which can be used for whatever purposes necessary.
+//! Module handles memory access observers,
+//! which store which accesses occur at a given memory location.
+//! 
+//! You would typically access an observer via the [`Simulator::observer`] field.
+//! This [`AccessObserver`] can be used to read or update accesses via its [`get_mem_accesses`]
+//! and [`update_mem_accesses`] methods.
+//! 
+//! [`Simulator::observer`]: crate::sim::Simulator::observer
+//! [`get_mem_accesses`]: AccessObserver::get_mem_accesses
+//! [`update_mem_accesses`]: AccessObserver::update_mem_accesses
 
 use std::collections::BTreeMap;
 
 /// The set of accesses which have occurred at this location.
+/// 
+/// ## Example
+/// 
+/// ```
+/// # use lc3_ensemble::sim::observer::AccessSet;
+/// 
+/// let accesses = AccessSet::READ;
+/// assert!(accesses.accessed());
+/// assert!(accesses.read());
+/// assert!(!accesses.written());
+/// assert!(!accesses.modified());
+/// ```
 #[derive(Default, Clone, Copy)]
 pub struct AccessSet(u8);
 impl AccessSet {
@@ -65,6 +85,7 @@ pub struct AccessObserver {
     // but reg/PC/PSR/MCR aren't exactly encapsulated in this way.
 }
 impl AccessObserver {
+    /// Creates a new access observer.
     pub fn new() -> Self {
         Self {
             mem: Default::default()


### PR DESCRIPTION
This update revises the `ChangeObserver` API into the `AccessObserver` API, allowing all memory accesses to be observed and introduces the `mmap_internal` API to expose internal registers as MMIO.